### PR TITLE
creating/updating a pin creates an edit object, plus various fixes

### DIFF
--- a/models.py
+++ b/models.py
@@ -81,7 +81,7 @@ class Pin(db.Model, SerializerMixin):
     world_id = db.Column(db.Integer, db.ForeignKey('worlds.id'), nullable=False)
     edits = db.relationship('Edit', backref='pin', lazy=True)
 
-    serialize_only = ('id', 'position_x', 'position_y', 'symbol', 'world_id', 'edits.id')
+    serialize_rules = ('-edits.pin',)
 
     def __init__(self, position_x, position_y, symbol, world_id):
         self.position_x = position_x

--- a/permissions.py
+++ b/permissions.py
@@ -9,7 +9,9 @@ def is_administrator(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         user = User.query.get(get_jwt_identity()['id'])
-        if (user.role != User.Role.ADMIN.value):
+        if (not user.is_active):
+            return Response('account is locked', status=403)
+        if (user.role not in [User.Role.ADMIN]):
             return Response('requires administrator account', status=403)
         return func(*args, **kwargs)
     return wrapper
@@ -18,7 +20,9 @@ def is_member(func, **kwargs):
     @wraps(func)
     def wrapper(*args, **kwargs):
         user = User.query.get(get_jwt_identity()['id'])
-        if (user.role in [User.Role.MEMBER.value, User.Role.ADMIN.value]):
+        if (not user.is_active):
+            return Response('account is locked', status=403)
+        if (user.role not in [User.Role.MEMBER, User.Role.ADMIN]):
             return Response('requires member account', status=403)
         return func(*args, **kwargs)
     return wrapper

--- a/views/campaigns.py
+++ b/views/campaigns.py
@@ -1,4 +1,5 @@
 from flask import current_app, Blueprint, jsonify, request, Response
+from flask_jwt_extended import jwt_required
 from werkzeug.utils import secure_filename
 
 from models import db, Campaign

--- a/views/edits.py
+++ b/views/edits.py
@@ -7,11 +7,13 @@ from permissions import is_administrator, is_member
 edits = Blueprint('edits', __name__, url_prefix='/api/edits')
 
 @edits.route('', methods=['GET'])
+@jwt_required
 @is_member
 def ListEdits():
     return jsonify([edit.to_dict() for edit in Edit.query.all()])
 
 @edits.route('', methods=['POST'])
+@jwt_required
 @is_member
 def CreateEdit():
     json = request.json
@@ -26,6 +28,7 @@ def CreateEdit():
         return Response('error creating record', status=400)
 
 @edits.route('/<id>', methods=['GET'])
+@jwt_required
 @is_member
 def RetrieveEdit(id=0):
     return jsonify(Edit.query.get_or_404(id).to_dict())

--- a/views/pins.py
+++ b/views/pins.py
@@ -1,21 +1,28 @@
 from flask import current_app, Blueprint, jsonify, request, Response
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_jwt_identity, jwt_required
 
-from models import db, Pin
+from models import db, Edit, Pin
 from permissions import is_administrator, is_member
 
 pins = Blueprint('pins', __name__, url_prefix='/api/pins')
 
 @pins.route('', methods=['GET'])
+@jwt_required
+@is_member
 def ListPins():
     return jsonify([pin.to_dict() for pin in Pin.query.all()])
 
 @pins.route('', methods=['POST'])
+@jwt_required
+@is_member
 def CreatePin():
     json = request.json
     try:
-        newPin = Pin(json['position_x'], json['position_y'], json['symbol'], json['world']['id'])
+        newPin = Pin(json['position_x'], json['position_y'], json['symbol'], json['world_id'])
         db.session.add(newPin)
+        db.session.commit()
+        newEdit = Edit(json['details'], newPin.id, get_jwt_identity()['id'])
+        db.session.add(newEdit)
         db.session.commit()
         data = jsonify(newPin.to_dict())
         data.status_code = 201
@@ -24,18 +31,29 @@ def CreatePin():
         return Response('error creating record', status=400)
 
 @pins.route('/<id>', methods=['GET'])
+@jwt_required
+@is_member
 def RetrievePin(id=0):
     return jsonify(Pin.query.get_or_404(id).to_dict())
 
 @pins.route('/<id>', methods=['PATCH'])
+@jwt_required
+@is_member
 def UpdatePin(id=0):
     pin = Pin.query.get_or_404(id)
     try:
         json = request.json
+        details = ''
+        if (pin.position_x != json['position_x'] or pin.position_y != json['position_y']):
+            details += f'Position changed from {pin.position_x}/{pin.position_y} to {json["position_x"]}/{json["position_y"]}\n'
         pin.position_x = json['position_x']
         pin.position_y = json['position_y']
-        pin.symbol = json['symbol']
-        pin.world_id = json['world']['id']
+        if (pin.symbol != json['symbol']):
+            details += f'Symbol changed from {pin.symbol} to {json["symbol"]}\n'
+            pin.symbol = json['symbol']
+        db.session.commit()
+        newEdit = Edit(details, pin.id, get_jwt_identity()['id'])
+        db.session.add(newEdit)
         db.session.commit()
         return jsonify(pin.to_dict())
     except:

--- a/views/worlds.py
+++ b/views/worlds.py
@@ -1,4 +1,5 @@
 from flask import current_app, Blueprint, jsonify, request, Response
+from flask_jwt_extended import jwt_required
 from werkzeug.utils import secure_filename
 
 from models import db, World


### PR DESCRIPTION
Made it so that creating a Pin or updating its position/symbol will create an Edit object so that history can be easily tracked.

Adjusted the serialization of the Pin object to return more data about the Edit objects that belong to it.

Adjusted the permission decorators to also check if the account is_active, no locked accounts should have permissions.

Fixed some missing decorators on some of the endpoints.