### PR TITLE
made campaigns serialize more world and pin data, added a name query …

### DIFF
--- a/models.py
+++ b/models.py
@@ -54,13 +54,15 @@ class Campaign(db.Model, SerializerMixin):
     image = db.Column(db.String(), nullable=False, unique=True)
     worlds = db.relationship('World', backref='campaign', lazy=True)
     is_default = db.Column(db.Boolean())
+    is_archived = db.Column(db.Boolean())
 
-    serialize_only = ('id', 'name', 'image', 'is_default', 'worlds.id', 'worlds.name')
+    serialize_rules = ('-worlds.campaign',)
 
     def __init__(self, name, image, is_default=False):
         self.name = name
         self.image = image
         self.is_default = is_default
+        self.is_archived = False
 
     def __repr__(self):
         return f'{self.id}: {self.name}'


### PR DESCRIPTION
Campaign serialization should now include all data required to load its worlds and its pins.

Added an endpoint to allow getting a campaign by name. 

`/api/campaigns/q?name=buttface` should return a campaign with name buttface or 404 if not found.

Added a bool for archiving campaigns. The default list endpoint will only return non-archived campaigns. Added a separate endpoint to return archived campaigns.