### PR TITLE
added refresh tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ def create_app():
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ['DATABASE_URL']
     app.config['SECRET_KEY'] = "SUPER-SECRET"
+    app.config['JWT_ACCESS_TOKEN_EXPIRES'] = 300 # 5 minutes
+    app.config['JWT_REFRESH_TOKEN_EXPIRES'] = 86400 # 1 day
     
     from models import db
     db.init_app(app)


### PR DESCRIPTION
Added refresh tokens to handle session persistence.

Access token is set to 5 minute lifespan, refresh token set to 1 day.

Logging in or registering sends a refresh token in an httponly cookie. There is now a /users/refresh endpoint to read that token and send back a new access token. There is also a /users/logout endpoint to delete the cookie.