### PR TITLE
added query endpoint to views/worlds

### DIFF
--- a/tests/test_worlds.py
+++ b/tests/test_worlds.py
@@ -57,3 +57,9 @@ class WorldTests(BasicTests):
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertDictContainsSubset({'image': '/mediafiles/updatedname.png', 'name': 'updated_name'}, data)
+
+    def test_query_name(self):
+        response = self.request(f'/api/worlds/q?campaign={self.DEFAULT_CAMPAIGN.name}&world={self.DEFAULT_WORLD.name}',
+                                headers={'Authorization': self.DEFAULT_TOKEN})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.DEFAULT_WORLD.to_dict(), response.get_json())

--- a/views/worlds.py
+++ b/views/worlds.py
@@ -3,7 +3,7 @@ from flask_jwt_extended import jwt_required
 from sqlalchemy.exc import IntegrityError
 from werkzeug.utils import secure_filename
 
-from models import db, World
+from models import db, Campaign, World
 from permissions import is_administrator, is_verified
 from upload import allowed_file
 
@@ -69,3 +69,14 @@ def UpdateWorld(id=0):
         return jsonify(world.to_dict())
     except IntegrityError as error:
         return Response(error.args[0], status=400)
+
+
+@worlds.route('/q', methods=['GET'])
+@jwt_required
+@is_verified
+def NameQuery():
+    campaign_name = request.args.get('campaign')
+    world_name = request.args.get('world')
+    return jsonify(World.query.join(Campaign)
+                   .filter(Campaign.name == campaign_name, World.name == world_name)
+                   .first_or_404().to_dict())


### PR DESCRIPTION
Pull request to go with the frontend pull request for altering campaign route structure.

Just adds a new endpoint to the worlds views. A get endpoint at /q that takes two query parameters, a campaign name as 'campaign' and a world name as 'world' and returns the corresponding world.