### PR TITLE
changed x_coord of pin to a string

### DIFF
--- a/models.py
+++ b/models.py
@@ -153,7 +153,7 @@ class Pin(db.Model, SerializerMixin):
     respawn = db.Column(db.Integer)
     world_id = db.Column(db.Integer, db.ForeignKey('worlds.id'), nullable=False)
     edits = db.relationship('Edit', backref='pin', lazy=True, cascade='all, delete')
-    x_cord = db.Column(db.Float)
+    x_cord = db.Column(db.String(1))
     y_cord = db.Column(db.Float)
 
     serialize_rules = ('-edits.pin',)


### PR DESCRIPTION
Very small change, the x_cord column should be a string, not a number. The game uses letters for the x coordinate and numbers for the y.