### PR TITLE
added bear and gryphon to animal list

### DIFF
--- a/migrations/versions/283f5f053505_.py
+++ b/migrations/versions/283f5f053505_.py
@@ -1,0 +1,25 @@
+"""empty message
+
+Revision ID: 283f5f053505
+Revises: 341063e49c43
+Create Date: 2020-11-19 18:47:59.230119
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '283f5f053505'
+down_revision = '341063e49c43'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE resource ADD VALUE 'BEAR'")
+    op.execute("ALTER TYPE resource ADD VALUE 'GRYPHON'")
+
+
+def downgrade():
+    pass

--- a/models.py
+++ b/models.py
@@ -140,6 +140,8 @@ class Pin(db.Model, SerializerMixin):
         AUROCH = 'auroch'
         ELK = 'elk'
         WOLF = 'wolf'
+        GRYPHON = 'gryphon'
+        BEAR = 'bear'
         HUMAN = 'human'
         ELVEN = 'elven'
         MONSTER = 'monster'


### PR DESCRIPTION
Backend request to allow the frontend request of same name to function.

Adds the gryphon and bear animals to the animal list. The migration commands are custom and should serve as a future example for doing this.